### PR TITLE
入力設定

### DIFF
--- a/contents.py
+++ b/contents.py
@@ -54,13 +54,8 @@ class Contents:
             QgsProject.instance().crs()
         )
 
-        input_type = {
-            "'xml'  または  'xml'を含む'zip'": 1,
-            "'xml'を含むフォルダ'": 2,
-        }
-        for key in input_type:
-            self.dlg.comboBox_inputType.addItem(key, input_type[key])
-        self.dlg.comboBox_inputType.activated.connect(self.switch_input_type)
+        self.dlg.radioButton_xmlzipfile.toggled.connect(self.switch_input_type)
+        self.dlg.radioButton_folder.toggled.connect(self.switch_input_type)
 
         self.dlg.button_box.accepted.connect(self.convert_DEM)
         self.dlg.button_box.rejected.connect(self.dlg_cancel)
@@ -138,7 +133,7 @@ class Contents:
         self.dlg.hide()
 
     def switch_input_type(self):
-        if self.dlg.comboBox_inputType.currentData() == 1:
+        if self.dlg.radioButton_xmlzipfile.isChecked():
             self.dlg.mQgsFileWidget_inputPath.setStorageMode(
                 QgsFileWidget.GetMultipleFiles
             )

--- a/quick_dem_for_jp_dialog_base.ui
+++ b/quick_dem_for_jp_dialog_base.ui
@@ -42,13 +42,26 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="comboBox_inputType">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <widget class="QRadioButton" name="radioButton_xmlzipfile">
+          <property name="text">
+           <string>'xml'または'xml'を含む'zip'</string>
           </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <attribute name="buttonGroup">
+            <string notr="true">buttonGroup_fileformat</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButton_folder">
+          <property name="text">
+           <string>'xml'を含むフォルダ</string>
+          </property>
+          <attribute name="buttonGroup">
+            <string notr="true">buttonGroup_fileformat</string>
+          </attribute>
          </widget>
         </item>
        </layout>


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #70 

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->
- 入力の形式設定がComboboxではなく、Radiobuttonの方がわかりやすい
- ZIP file内にサブフォルダがあったら「XMLファイルが存在しません」エラーを解決
- unzipフォルダーが処理後に残っていて、それを削除
- 1m DEM fileになりましたので、ZIP fileがいけるためにSize limitを増えました、

UI Before
<img width="466" alt="image" src="https://github.com/MIERUNE/QuickDEM4JP/assets/26103833/a88fad21-ebbd-4c5d-a20b-81736e7ab6c1">

UI After
<img width="466" alt="image" src="https://github.com/MIERUNE/QuickDEM4JP/assets/26103833/52a2a9dd-4c27-4b8d-b949-6ca68765032d">


### Test
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動の動作確認が必要なら、手順を簡単に伝えてください。その他連絡事項など。 -->
- set submodule to `fix/zip-file` branch
- Radiobuttonをクリックしてファイルかフォルダーを指定できるかを確認
- サブフォルダーが含めているZIPファイルでConvertしてみる
- 処理後にZIPのExtracted Folderを無事に削除されるかを確認

- OKなら本PRと、 Submoduleの https://github.com/MIERUNE/convert_fgd_dem/pull/15 PRをマージ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - リリース時にプラグインをエクスポートするためのGitHub Actionsワークフローを追加。

- **改良**
  - QuickDEMforJPプラグインのユーザーインターフェースを改善し、ファイル操作を強化。
  - UIにQComboBoxの代わりに2つのQRadioButtonを追加し、入力タイプを切り替え可能に。

- **バグ修正**
  - ファイルウィジェットのストレージモードとダイアログタイトルを修正。
  - 情報メッセージボックスの文字エンコーディングを改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->