### PR TITLE
GeoTiffとTerrainRGBの保存先を分ける

### DIFF
--- a/contents.py
+++ b/contents.py
@@ -42,11 +42,15 @@ class Contents:
         self.dlg.mQgsFileWidget_inputPath.setFilter("*.xml;;*.zip")
 
         self.dlg.mQgsFileWidget_outputPath.setFilePath(QgsProject.instance().homePath())
-        self.dlg.mQgsFileWidget_outputPath.setStorageMode(
-            QgsFileWidget.StorageMode.SaveFile
-        )
         self.dlg.mQgsFileWidget_outputPath.setFilter("*.tiff")
         self.dlg.mQgsFileWidget_outputPath.setDialogTitle(
+            "保存ファイルを選択してください"
+        )
+        self.dlg.mQgsFileWidget_outputPathTerrain.setFilePath(
+            QgsProject.instance().homePath()
+        )
+        self.dlg.mQgsFileWidget_outputPathTerrain.setFilter("*.tiff")
+        self.dlg.mQgsFileWidget_outputPathTerrain.setDialogTitle(
             "保存ファイルを選択してください"
         )
 

--- a/contents.py
+++ b/contents.py
@@ -123,20 +123,38 @@ class Contents:
 
         try:
             if do_GeoTiff:
+                # check if directory exists
+                directory = os.path.dirname(self.output_path)
+                if not os.path.isdir(directory):
+                    QMessageBox.information(
+                        None, "エラー", f"Cannot find output folder.\n{directory}"
+                    )
+                    return
                 filename = os.path.basename(self.output_path)
+                # Add .tiff to output path if missing
+                if not filename.lower().endswith(".tiff"):
+                    filename += ".tiff"
                 self.convert(filename=filename, rgbify=False)
                 if do_add_layer:
                     self.add_layer(
                         tiff_name=filename, layer_name=os.path.splitext(filename)[0]
                     )
             if do_TerrainRGB:
-                filename = f"{os.path.splitext(self.output_path)[0]}_Terrain-RGB{os.path.splitext(os.path.basename(self.output_path))[1]}"
+                # check if directory exists
+                directory = os.path.dirname(self.output_path_terrain)
+                if not os.path.isdir(directory):
+                    QMessageBox.information(
+                        None, "エラー", f"Cannot find output folder.\n{directory}"
+                    )
+                    return
                 filename = os.path.basename(self.output_path_terrain)
+                # Add .tiff to output path if missing
+                if not filename.lower().endswith(".tiff"):
+                    filename += ".tiff"
                 self.convert(filename=filename, rgbify=True)
                 if do_add_layer:
                     self.add_layer(
-                        tiff_name=filename,
-                        layer_name=os.path.splitext(filename)[0],
+                        tiff_name=filename, layer_name=os.path.splitext(filename)[0]
                     )
         except Exception as e:
             QMessageBox.information(None, "エラー", f"{e}")

--- a/contents.py
+++ b/contents.py
@@ -68,20 +68,18 @@ class Contents:
         self.dlg.button_box.accepted.connect(self.convert_DEM)
         self.dlg.button_box.rejected.connect(self.dlg_cancel)
 
-    def convert(self, filename, rgbify):
+    def convert(self, output_path, filename, rgbify):
         converter = Converter(
             import_path=self.import_path,
-            output_path=os.path.dirname(self.output_path),
+            output_path=output_path,
             output_epsg=self.output_epsg,
             file_name=filename,
             rgbify=rgbify,
         )
         converter.dem_to_geotiff()
 
-    def add_layer(self, tiff_name, layer_name):
-        layer = QgsRasterLayer(
-            os.path.join(os.path.dirname(self.output_path), tiff_name), layer_name
-        )
+    def add_layer(self, output_path, tiff_name, layer_name):
+        layer = QgsRasterLayer(os.path.join(output_path, tiff_name), layer_name)
         QgsProject.instance().addMapLayer(layer)
 
     def convert_DEM(self):
@@ -134,10 +132,17 @@ class Contents:
                 # Add .tiff to output path if missing
                 if not filename.lower().endswith(".tiff"):
                     filename += ".tiff"
-                self.convert(filename=filename, rgbify=False)
+
+                self.convert(
+                    output_path=os.path.dirname(self.output_path),
+                    filename=filename,
+                    rgbify=False,
+                )
                 if do_add_layer:
                     self.add_layer(
-                        tiff_name=filename, layer_name=os.path.splitext(filename)[0]
+                        os.path.dirname(self.output_path),
+                        tiff_name=filename,
+                        layer_name=os.path.splitext(filename)[0],
                     )
             if do_TerrainRGB:
                 # check if directory exists
@@ -151,10 +156,17 @@ class Contents:
                 # Add .tiff to output path if missing
                 if not filename.lower().endswith(".tiff"):
                     filename += ".tiff"
-                self.convert(filename=filename, rgbify=True)
+
+                self.convert(
+                    os.path.dirname(self.output_path_terrain),
+                    filename=filename,
+                    rgbify=True,
+                )
                 if do_add_layer:
                     self.add_layer(
-                        tiff_name=filename, layer_name=os.path.splitext(filename)[0]
+                        os.path.dirname(self.output_path_terrain),
+                        tiff_name=filename,
+                        layer_name=os.path.splitext(filename)[0],
                     )
         except Exception as e:
             QMessageBox.information(None, "エラー", f"{e}")

--- a/contents.py
+++ b/contents.py
@@ -95,8 +95,17 @@ class Contents:
             return
 
         self.output_path = self.dlg.mQgsFileWidget_outputPath.filePath()
-        if not self.output_path:
-            QMessageBox.information(None, "エラー", "DEMの出力先パスを入力してください")
+        if do_GeoTiff and not self.output_path:
+            QMessageBox.information(
+                None, "エラー", "GeoTIFFの出力先パスを入力してください"
+            )
+            return
+
+        self.output_path_terrain = self.dlg.mQgsFileWidget_outputPathTerrain.filePath()
+        if do_TerrainRGB and not self.output_path_terrain:
+            QMessageBox.information(
+                None, "エラー", "Terrain RGBの出力先パスを入力してください"
+            )
             return
 
         self.output_epsg = (
@@ -118,11 +127,12 @@ class Contents:
                     )
             if do_TerrainRGB:
                 filename = f"{os.path.splitext(self.output_path)[0]}_Terrain-RGB{os.path.splitext(os.path.basename(self.output_path))[1]}"
+                filename = os.path.basename(self.output_path_terrain)
                 self.convert(filename=filename, rgbify=True)
                 if do_add_layer:
                     self.add_layer(
                         tiff_name=filename,
-                        layer_name=f"{os.path.splitext(os.path.basename(self.output_path))[0]}_Terrain-RGB",
+                        layer_name=os.path.splitext(filename)[0],
                     )
         except Exception as e:
             QMessageBox.information(None, "エラー", f"{e}")

--- a/contents.py
+++ b/contents.py
@@ -54,6 +54,10 @@ class Contents:
             "保存ファイルを選択してください"
         )
 
+        # set terrain path if changed
+        self.dlg.mQgsFileWidget_outputPath.fileChanged.connect(self.set_terrain_path)
+        self.dlg.checkBox_outputTerrainRGB.stateChanged.connect(self.set_terrain_path)
+
         self.dlg.mQgsProjectionSelectionWidget_outputCrs.setCrs(
             QgsProject.instance().crs()
         )
@@ -153,3 +157,16 @@ class Contents:
             )
         else:
             self.dlg.mQgsFileWidget_inputPath.setStorageMode(QgsFileWidget.GetDirectory)
+
+    def set_terrain_path(self):
+        # set Terrain file path automatically if path is not defined and Geotiff path is defined
+        geotiff_path = self.dlg.mQgsFileWidget_outputPath.filePath()
+        if (
+            self.dlg.checkBox_outputTerrainRGB.isChecked()
+            and os.path.splitext(geotiff_path)[1] == ".tiff"
+        ):
+            terrain_path = (
+                os.path.splitext(geotiff_path)[0]
+                + f"_Terrain-RGB{os.path.splitext(os.path.basename(geotiff_path))[1]}"
+            )
+            self.dlg.mQgsFileWidget_outputPathTerrain.setFilePath(terrain_path)

--- a/contents.py
+++ b/contents.py
@@ -182,6 +182,9 @@ class Contents:
         if (
             self.dlg.checkBox_outputTerrainRGB.isChecked()
             and os.path.splitext(geotiff_path)[1] == ".tiff"
+            and not self.dlg.mQgsFileWidget_outputPathTerrain.filePath()
+            .lower()
+            .endswith(".tiff")
         ):
             terrain_path = (
                 os.path.splitext(geotiff_path)[0]

--- a/quick_dem_for_jp_dialog_base.ui
+++ b/quick_dem_for_jp_dialog_base.ui
@@ -109,27 +109,8 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>形式</string>
-          </property>
-         </widget>
-        </item>
-        <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
          <widget class="QCheckBox" name="checkBox_outputGeoTiff">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -140,22 +121,17 @@
           <property name="text">
            <string>GeoTiff</string>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="checked">
            <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QCheckBox" name="checkBox_outputTerrainRGB">
-          <property name="text">
-           <string>Terrain RGB</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QLabel" name="label_2">
           <property name="sizePolicy">
@@ -177,6 +153,55 @@
         </item>
         <item>
          <widget class="QgsFileWidget" name="mQgsFileWidget_outputPath">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="storageMode">
+           <enum>QgsFileWidget::GetDirectory</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+         <widget class="QCheckBox" name="checkBox_outputTerrainRGB">
+          <property name="text">
+           <string>Terrain RGB</string>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>出力先</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsFileWidget" name="mQgsFileWidget_outputPathTerrain">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>

--- a/quick_dem_for_jp_dialog_base.ui
+++ b/quick_dem_for_jp_dialog_base.ui
@@ -160,7 +160,7 @@
            </sizepolicy>
           </property>
           <property name="storageMode">
-           <enum>QgsFileWidget::GetDirectory</enum>
+           <enum>QgsFileWidget::SaveFile</enum>
           </property>
          </widget>
         </item>
@@ -209,7 +209,7 @@
            </sizepolicy>
           </property>
           <property name="storageMode">
-           <enum>QgsFileWidget::GetDirectory</enum>
+           <enum>QgsFileWidget::SaveFile</enum>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #29 
Close #64 

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->

<img width="456" alt="image" src="https://github.com/MIERUNE/QuickDEM4JP/assets/26103833/a3445fa5-c342-459f-80c2-eff27fb3a0cf">

https://github.com/MIERUNE/QuickDEM4JP/issues/29#issuecomment-858196181

```
ユーザーの手間を少なくするためにこんな風にするのはどうでしょう？

- ユーザがDEMGeoTiffのファイル名を指定する
- TerrainRGBのチェックボックスがONになっている or ONになったら、自動でTerrainRGBのファイル名指定のウィジェットにデフォルト値が入る（デフォルトで aaa_Terrain-RGB.tiffとか）
- ユーザが別のファイル名を指定したかったら、変更可能
```

### Test
①
- Geotiffの出力先を指定
- Terrain RGB をチェックする → 出力先が自動で `〇〇_Terrain-RGB.tiff`で指定される。
  - Terrain RGB出力先が.tiffですでに指定される場合、更新されない
  - Geotiffの出力先が.tiffではない場合、更新されない
- 実行する

②
- Terrain RGB をチェックする
- Geotiffの出力先を指定 → Terrain RGBの出力先が自動で `〇〇_Terrain-RGB.tiff`で指定される。
  - Terrain RGB出力先が.tiffですでに指定される場合、更新されない
- 実行する

 ③
 - 出力先を意地悪で手動で編集
   - .tiffを抜ける→ .tiffを自動で直される
   - 存在していないフォルダーを入力
  
### Note
- Submoduleの変更なし
- 追加Error messageが英語で、多言語化があとから実装する予定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - GeoTIFFおよびTerrain RGB出力パスの設定機能を追加
  - ファイル形式選択のためのラジオボタンを導入

- **改善**
  - Terrain出力パスの初期化と更新のためのシグナル接続を追加
  - GeoTIFFおよびTerrain RGB出力パスの管理を強化

- **UI変更**
  - `QComboBox`から`QRadioButton`への変更
  - GeoTIFFおよびTerrain RGBオプションのための`QCheckBox`を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->