### PR TITLE
Feat/offshore option

### DIFF
--- a/contents.py
+++ b/contents.py
@@ -69,12 +69,14 @@ class Contents:
         self.dlg.button_box.rejected.connect(self.dlg_cancel)
 
     def convert(self, output_path, filename, rgbify):
+
         converter = Converter(
             import_path=self.import_path,
             output_path=output_path,
             output_epsg=self.output_epsg,
             file_name=filename,
             rgbify=rgbify,
+            sea_at_zero=self.dlg.checkBox_sea_zero.isChecked(),
         )
         converter.dem_to_geotiff()
 
@@ -85,6 +87,7 @@ class Contents:
     def convert_DEM(self):
         do_GeoTiff = self.dlg.checkBox_outputGeoTiff.isChecked()
         do_TerrainRGB = self.dlg.checkBox_outputTerrainRGB.isChecked()
+
         if not do_GeoTiff and not do_TerrainRGB:
             QMessageBox.information(
                 None, "エラー", "出力形式にチェックを入れてください"

--- a/quick_dem_for_jp_dialog_base.ui
+++ b/quick_dem_for_jp_dialog_base.ui
@@ -108,7 +108,7 @@
       <string>出力設定</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
-      <item>
+     <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
          <widget class="QCheckBox" name="checkBox_outputGeoTiff">
@@ -247,6 +247,25 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox_sea_zero">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>海域標高を0mに設定する</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="checkBox_openLayers">


### PR DESCRIPTION
<!-- Close or Related Issues -->
Related #57 

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->
`海水面`と`海水底面`の-9999を0.0に変換オプション

<img width="452" alt="image" src="https://github.com/user-attachments/assets/64027796-3773-4653-ab25-83cb192bfddf">

[仕様書](https://fgd.gsi.go.jp/spec/2023/FGD_DLFileSpecV5.0.pdf)

### Test 
- 海域が含むエリアに、オプション付きとオプションなしでテスト

オプション無し
<img width="960" alt="image" src="https://github.com/user-attachments/assets/52665029-34e9-49c8-bd83-75ba831c487a">

オプション付き
<img width="879" alt="image" src="https://github.com/user-attachments/assets/4df3bfb2-f217-4f0d-9a16-7b7b6438bc00">


### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動の動作確認が必要なら、手順を簡単に伝えてください。その他連絡事項など。 -->

- SubmoduleにもPR確認とマージ
