### PR TITLE
Feat/progress bar

### DIFF
--- a/contents.py
+++ b/contents.py
@@ -75,7 +75,7 @@ class Contents:
     def convert(self, output_path, filename, rgbify):
         progress_dialog = ProgressDialog(None)
 
-        converter = Converter(
+        thread = Converter(
             import_path=self.import_path,
             output_path=output_path,
             output_epsg=self.output_epsg,
@@ -83,7 +83,15 @@ class Contents:
             rgbify=rgbify,
             sea_at_zero=self.dlg.checkBox_sea_zero.isChecked(),
         )
-        converter.dem_to_geotiff()
+
+        # progress dialog orchestation by process thread
+        thread.setMaximum.connect(progress_dialog.set_maximum)
+        thread.addProgress.connect(progress_dialog.add_progress)
+        thread.postMessage.connect(progress_dialog.set_message)
+        thread.setAbortable.connect(progress_dialog.set_abortable)
+        thread.processFinished.connect(progress_dialog.close)
+
+        thread.start()
         progress_dialog.exec_()
 
     def add_layer(self, output_path, tiff_name, layer_name):

--- a/contents.py
+++ b/contents.py
@@ -28,9 +28,10 @@ from qgis.core import QgsProject, QgsRasterLayer
 from qgis.gui import QgsFileWidget
 from PyQt5.QtWidgets import QMessageBox
 
-
 from .quick_dem_for_jp_dialog import QuickDEMforJPDialog
 from .convert_fgd_dem.src.convert_fgd_dem.converter import Converter
+
+from .progress_dialog import ProgressDialog
 
 
 class Contents:
@@ -72,6 +73,7 @@ class Contents:
         self.dlg.downloadButton.clicked.connect(self.on_download_page_clicked)
 
     def convert(self, output_path, filename, rgbify):
+        progress_dialog = ProgressDialog(None)
 
         converter = Converter(
             import_path=self.import_path,
@@ -82,6 +84,7 @@ class Contents:
             sea_at_zero=self.dlg.checkBox_sea_zero.isChecked(),
         )
         converter.dem_to_geotiff()
+        progress_dialog.exec_()
 
     def add_layer(self, output_path, tiff_name, layer_name):
         layer = QgsRasterLayer(os.path.join(output_path, tiff_name), layer_name)

--- a/contents.py
+++ b/contents.py
@@ -144,7 +144,7 @@ class Contents:
         do_add_layer = self.dlg.checkBox_openLayers.isChecked()
 
         try:
-            if do_GeoTiff:
+            if do_GeoTiff and not self.process_interrupted:
                 # check if directory exists
                 directory = os.path.dirname(self.output_path)
                 if not os.path.isdir(directory):
@@ -243,6 +243,7 @@ class Contents:
             QMessageBox.No,
         ):
             self.set_interrupted()
+            thread.process_interrupted = True
             self.abort_process(thread, progress_dialog)
 
     def abort_process(self, thread, progress_dialog: ProgressDialog) -> None:

--- a/contents.py
+++ b/contents.py
@@ -72,6 +72,8 @@ class Contents:
 
         self.dlg.downloadButton.clicked.connect(self.on_download_page_clicked)
 
+        self.process_interrupted = False
+
     def convert(self, output_path, filename, rgbify):
         progress_dialog = ProgressDialog(None)
 
@@ -84,6 +86,11 @@ class Contents:
             sea_at_zero=self.dlg.checkBox_sea_zero.isChecked(),
         )
 
+        progress_dialog.abortButton.clicked.connect(
+            lambda: [
+                self.on_abort_clicked(thread, progress_dialog),
+            ]
+        )
         # progress dialog orchestation by process thread
         thread.setMaximum.connect(progress_dialog.set_maximum)
         thread.addProgress.connect(progress_dialog.add_progress)
@@ -155,13 +162,13 @@ class Contents:
                     filename=filename,
                     rgbify=False,
                 )
-                if do_add_layer:
+                if do_add_layer and not self.process_interrupted:
                     self.add_layer(
                         os.path.dirname(self.output_path),
                         tiff_name=filename,
                         layer_name=os.path.splitext(filename)[0],
                     )
-            if do_TerrainRGB:
+            if do_TerrainRGB and not self.process_interrupted:
                 # check if directory exists
                 directory = os.path.dirname(self.output_path_terrain)
                 if not os.path.isdir(directory):
@@ -179,7 +186,7 @@ class Contents:
                     filename=filename,
                     rgbify=True,
                 )
-                if do_add_layer:
+                if do_add_layer and not self.process_interrupted:
                     self.add_layer(
                         os.path.dirname(self.output_path_terrain),
                         tiff_name=filename,
@@ -189,7 +196,9 @@ class Contents:
             QMessageBox.information(None, "エラー", f"{e}")
             return
 
-        QMessageBox.information(None, "完了", "処理が完了しました")
+        if not self.process_interrupted:
+            QMessageBox.information(None, "完了", "処理が完了しました")
+
         self.dlg.hide()
 
         return True
@@ -224,3 +233,24 @@ class Contents:
     def on_download_page_clicked(self):
         webbrowser.open("https://fgd.gsi.go.jp/download/")
         return
+
+    def on_abort_clicked(self, thread, progress_dialog: ProgressDialog) -> None:
+        if QMessageBox.Yes == QMessageBox.question(
+            None,
+            "Aborting",
+            "Are you sure to cancel process?",
+            QMessageBox.Yes,
+            QMessageBox.No,
+        ):
+            self.set_interrupted()
+            self.abort_process(thread, progress_dialog)
+
+    def abort_process(self, thread, progress_dialog: ProgressDialog) -> None:
+        if self.process_interrupted:
+            thread.exit()
+            progress_dialog.abort_dialog()
+            self.dlg_cancel()
+            return
+
+    def set_interrupted(self):
+        self.process_interrupted = True

--- a/progress_dialog.py
+++ b/progress_dialog.py
@@ -37,7 +37,6 @@ class ProgressDialog(QDialog):
 
     def abort_dialog(self):
         if self.abortButton.isEnabled():  # abort if possible
-            self.set_abort_flag_callback()
             self.abortButton.setEnabled(False)
             self.abortButton.setText(self.tr("Cancelling..."))
             self.close()
@@ -49,7 +48,7 @@ class ProgressDialog(QDialog):
         self.progressBar.setValue(self.progressBar.value() + value)
 
     def set_message(self, message: str):
-        self.label.setText(self.translate(message))
+        self.label.setText(message)
 
     def set_abortable(self, abortable=True):
         self.abortButton.setEnabled(abortable)
@@ -57,47 +56,3 @@ class ProgressDialog(QDialog):
     def close_dialog(self):
         print("closing")
         self.ui.close()
-
-    def translate(self, message):
-        # translate in this QDialog class to be detected by QLinguist.
-        if message == "Processing...":
-            translated_message = self.tr("Processing...")
-        elif message == "Finalizing...":
-            translated_message = self.tr("Finalizing...")
-        elif message == "Aborting":
-            translated_message = self.tr("Aborting")
-        elif message == "Are you sure to cancel process?":
-            translated_message = self.tr("Are you sure to cancel process?")
-        elif message == "Error":
-            translated_message = self.tr("Error")
-        elif message == "Output file is not defined.":
-            translated_message = self.tr("Output file is not defined.")
-        elif message == "Cannot find output folder.":
-            translated_message = self.tr("Cannot find output folder.")
-        elif message == "CRS of output file is not defined.":
-            translated_message = self.tr("CRS of output file is not defined.")
-        elif (
-            message
-            == "Target extent must not cross the International Date Line meridian."
-        ):
-            translated_message = self.tr(
-                "Target extent must not cross the International Date Line meridian."
-            )
-        elif message == "Too large amount of tiles ({})":
-            translated_message = self.tr("Too large amount of tiles ({})")
-        elif message == "Set a lower zoom level or extent to get less than {} tiles.":
-            translated_message = self.tr(
-                "Set a lower zoom level or extent to get less than {} tiles."
-            )
-        elif message == "Dowloading {} tiles may take a while. Process anyway?":
-            translated_message = self.tr(
-                "Dowloading {} tiles may take a while. Process anyway?"
-            )
-        elif message == "Warning":
-            translated_message = self.tr("Warning")
-        elif message == "DEM exported to Geotiff Format.":
-            translated_message = self.tr("DEM exported to Geotiff Format.")
-        else:
-            # fallback origin message
-            translated_message = message
-        return translated_message

--- a/progress_dialog.py
+++ b/progress_dialog.py
@@ -1,0 +1,103 @@
+import os
+
+# QGIS-API
+from qgis.PyQt import uic
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QKeyEvent
+from PyQt5.QtWidgets import QDialog
+
+
+class ProgressDialog(QDialog):
+    def __init__(self, set_abort_flag_callback):
+        """_summary_
+
+        Args:
+            set_abort_flag_callback (optional, method()): called when abort clicked
+        """
+        super().__init__()
+        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
+        self.ui = uic.loadUi(
+            os.path.join(os.path.dirname(__file__), "progress_dialog.ui"), self
+        )
+
+        self.set_abort_flag_callback = set_abort_flag_callback
+        self.init_ui()
+
+    def init_ui(self):
+        self.label.setText(self.tr("Initializing process..."))
+        self.progressBar.setValue(0)
+        self.progressBar.setMaximum(0)
+        self.abortButton.setEnabled(True)
+        self.abortButton.setText(self.tr("Cancel"))
+
+    def keyPressEvent(self, event: QKeyEvent):
+        if event.key() == Qt.Key_Escape:
+            return
+        super().keyPressEvent(event)
+
+    def abort_dialog(self):
+        if self.abortButton.isEnabled():  # abort if possible
+            self.set_abort_flag_callback()
+            self.abortButton.setEnabled(False)
+            self.abortButton.setText(self.tr("Cancelling..."))
+            self.close()
+
+    def set_maximum(self, value: int):
+        self.progressBar.setMaximum(value)
+
+    def add_progress(self, value: int):
+        self.progressBar.setValue(self.progressBar.value() + value)
+
+    def set_message(self, message: str):
+        self.label.setText(self.translate(message))
+
+    def set_abortable(self, abortable=True):
+        self.abortButton.setEnabled(abortable)
+
+    def close_dialog(self):
+        print("closing")
+        self.ui.close()
+
+    def translate(self, message):
+        # translate in this QDialog class to be detected by QLinguist.
+        if message == "Processing...":
+            translated_message = self.tr("Processing...")
+        elif message == "Finalizing...":
+            translated_message = self.tr("Finalizing...")
+        elif message == "Aborting":
+            translated_message = self.tr("Aborting")
+        elif message == "Are you sure to cancel process?":
+            translated_message = self.tr("Are you sure to cancel process?")
+        elif message == "Error":
+            translated_message = self.tr("Error")
+        elif message == "Output file is not defined.":
+            translated_message = self.tr("Output file is not defined.")
+        elif message == "Cannot find output folder.":
+            translated_message = self.tr("Cannot find output folder.")
+        elif message == "CRS of output file is not defined.":
+            translated_message = self.tr("CRS of output file is not defined.")
+        elif (
+            message
+            == "Target extent must not cross the International Date Line meridian."
+        ):
+            translated_message = self.tr(
+                "Target extent must not cross the International Date Line meridian."
+            )
+        elif message == "Too large amount of tiles ({})":
+            translated_message = self.tr("Too large amount of tiles ({})")
+        elif message == "Set a lower zoom level or extent to get less than {} tiles.":
+            translated_message = self.tr(
+                "Set a lower zoom level or extent to get less than {} tiles."
+            )
+        elif message == "Dowloading {} tiles may take a while. Process anyway?":
+            translated_message = self.tr(
+                "Dowloading {} tiles may take a while. Process anyway?"
+            )
+        elif message == "Warning":
+            translated_message = self.tr("Warning")
+        elif message == "DEM exported to Geotiff Format.":
+            translated_message = self.tr("DEM exported to Geotiff Format.")
+        else:
+            # fallback origin message
+            translated_message = message
+        return translated_message

--- a/progress_dialog.ui
+++ b/progress_dialog.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>87</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Processing...</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="textVisible">
+      <bool>true</bool>
+     </property>
+     <property name="invertedAppearance">
+      <bool>false</bool>
+     </property>
+     <property name="textDirection">
+      <enum>QProgressBar::TopToBottom</enum>
+     </property>
+     <property name="format">
+      <string>%v/%m</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Progressing</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="abortButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #14 

### Description（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- 何のために、どのような変更をしますか？ -->

- 進捗バー追加
  - XML fileを1個読みこべたら進捗する
  - Terrain RGBもやったら進捗バーが2回目行う
<img width="363" alt="image" src="https://github.com/user-attachments/assets/c2d5b929-3b59-4708-906f-2d116c9d4c8a">

### Test
- 複数XMLやZIPファイルをInputで選択して実行してファイルが作成まで確認
- 処理途中に止まってみる→レイヤ追加されない & TIFFを作成されないを確認

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動の動作確認が必要なら、手順を簡単に伝えてください。その他連絡事項など。 -->
- 進捗Dialogが英語で、これから多言語化を対応する。
- Submodule のもPR確認&マージする
- Submoduleのプラグイン外環境の動作確認が個別で


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- コンバージョン中に進行状況を表示する新しい `ProgressDialog` を追加しました。これにより、ユーザーはリアルタイムでフィードバックを受け取ることができ、処理を中断するオプションも提供されます。

- **バグ修正**
	- コンバージョン処理が中断された場合のハンドリングを改善しました。

- **ドキュメント**
	- 新しいユーザーインターフェースファイル `progress_dialog.ui` を追加し、進行状況表示のためのダイアログウィンドウを定義しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->