### PR TITLE
handle `QVariant` Error

### DIFF
--- a/quick_dem_for_jp.py
+++ b/quick_dem_for_jp.py
@@ -43,7 +43,7 @@ class QuickDEMforJP:
         self.icon_path = os.path.join(self.plugin_dir, "icon.png")
         # initialize locale
         if QSettings().value("locale/userLocale") is not None:
-            locale = QSettings().value("locale/userLocale")[0:2]
+            locale = str(QSettings().value("locale/userLocale"))[0:2]
         else:
             locale = "en"
         locale_path = os.path.join(


### PR DESCRIPTION
<!-- Close or Related Issues -->
#90 

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

QVariant 型は直接スライス操作（例: [0:2]）ができないため、まず文字列に変換する必要がある。


```py
locale = QSettings().value("locale/userLocale")[0:2]
```

```py
locale = str(QSettings().value("locale/userLocale"))[0:2]
```

### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

None / なし





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- ユーザーの言語設定がより正確に反映されるよう、取得方法を改善しました。この修正により、特定の地域設定で以前より安定した表示が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->